### PR TITLE
fix: Only call mkdir on the cache_path if cache is enabled

### DIFF
--- a/src/pymetadata/ontologies/ols.py
+++ b/src/pymetadata/ontologies/ols.py
@@ -86,7 +86,7 @@ class OLSQuery:
         self.cache_path = cache_path / "ols"
         self.cache = cache
 
-        if not self.cache_path.exists():
+        if cache and not self.cache_path.exists():
             self.cache_path.mkdir(parents=True)
 
     def get_iri(self, ontology: str, term: str) -> str:


### PR DESCRIPTION
* [ ] fix #(issue number): there was no open issue
* [x] description of feature/fix: the cache dir is always created, even if not used. this is bad for read only file systems
* [x] tests added/passed: all passed by running `docker run --rm -it -v $PWD:/app python:3 bash -c "cd /app && pip install -e .[development] && tox -p`, maybe this command can be put in the documentation for linux users
* [ ] add an entry to the [next release](../release-notes/next-release.md): unsure, if necessary
