### PR TITLE
fix: Drop legacy UUID package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ zip_safe = True
 python_requires = >=3.9
 install_requires = 
 	depinfo>=1.7
-	uuid>=1.30
 	lxml>=4.9
 	rich>=13.6
 	requests>=2.31


### PR DESCRIPTION
This module is shadowing the python internal uuid lib when using poetry. Using poetry, the [legacy UUID package](https://pypi.org/project/uuid/) with python2 syntax is being used and throws a syntax error "... 32L"

* [ ] fix #(issue number): There is no open issue
* [x] description of feature/fix: see above
* [x] tests added/passed: all tests pass
* [ ] add an entry to the [next release](../release-notes/next-release.md): It shouldn't change anything as i think

the python import uuid uses the uuid.py from the python library anyways:

![image](https://github.com/matthiaskoenig/pymetadata/assets/28303440/a6a3451b-7ed1-4e3b-a828-a86afdac4dd3)
